### PR TITLE
Add Twitter auth script and workflow

### DIFF
--- a/.github/workflows/test-twitter-auth.yml
+++ b/.github/workflows/test-twitter-auth.yml
@@ -1,0 +1,27 @@
+name: Test Twitter Auth
+
+on:
+  workflow_dispatch:
+
+jobs:
+  auth-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install tweepy
+
+      - name: Run auth test
+        env:
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_SECRET: ${{ secrets.TWITTER_ACCESS_SECRET }}
+        run: python test_auth.py

--- a/test_auth.py
+++ b/test_auth.py
@@ -1,0 +1,26 @@
+import os
+import tweepy
+
+def main():
+    print("\U0001F512 Testing Twitter API credentials...")
+
+    auth = tweepy.OAuth1UserHandler(
+        os.getenv("TWITTER_API_KEY"),
+        os.getenv("TWITTER_API_SECRET"),
+        os.getenv("TWITTER_ACCESS_TOKEN"),
+        os.getenv("TWITTER_ACCESS_SECRET")
+    )
+
+    api = tweepy.API(auth)
+
+    try:
+        user = api.verify_credentials()
+        if user:
+            print(f"\u2705 Auth successful. Logged in as: @{user.screen_name}")
+        else:
+            print("\u274C Auth failed. No user returned.")
+    except Exception as e:
+        print("\u274C Auth exception:", e)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `test_auth.py` script for checking Twitter API credentials
- create `test-twitter-auth` GitHub Actions workflow for manual auth tests

## Testing
- `python -m py_compile test_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_6848c932396c832694e48ff7d38c653d