### PR TITLE
Update favicon links

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>RecipeSnap AI - Smarter Cooking Starts Here</title>
-  <link rel="icon" type="image/x-icon" href="assets/images/RecipeSnapLogo.ico">
+  <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
   <style>
     :root {
       --primary-color: #7b2cbf;

--- a/privacy.html
+++ b/privacy.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Privacy Policy - RecipeSnap AI</title>
-  <link rel="icon" type="image/x-icon" href="assets/images/RecipeSnapLogo.ico">
+  <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
   <style>
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;

--- a/recipe.html
+++ b/recipe.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Recipe | RecipeSnap AI</title>
-  <link rel="icon" type="image/x-icon" href="assets/images/RecipeSnapLogo.ico">
+  <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
   <style>
     :root {
       --primary-color: #7b2cbf;

--- a/support.html
+++ b/support.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Support - RecipeSnap AI</title>
-  <link rel="icon" type="image/x-icon" href="assets/images/RecipeSnapLogo.ico">
+  <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
   <style>
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;

--- a/terms.html
+++ b/terms.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Terms & Conditions - RecipeSnap AI</title>
-  <link rel="icon" type="image/x-icon" href="assets/images/RecipeSnapLogo.ico">
+  <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
   <style>
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;


### PR DESCRIPTION
## Summary
- use the `favicon.ico` for the site icon across all pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tweepy')*

------
https://chatgpt.com/codex/tasks/task_e_6848d23bcf908326af03d01b2aa17491