### PR TITLE
Add terms-of-use page and shared theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ This repository contains the static website for RecipeSnap AI.
 
 - `index.html` – marketing homepage
 - `support.html` – user support information
-- Additional pages: `recipe.html`, `terms.html`, `privacy.html`
+- Additional pages: `recipe.html`, `terms.html`, `terms-of-use.html`, `privacy.html`
 - Assets (images and videos) are stored under the `assets/` directory.
+- Common styling lives in `assets/theme.css`.

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -1,0 +1,51 @@
+:root {
+  --primary-color: #7b2cbf;
+  --secondary-color: #5a189a;
+  --accent-color: #3c096c;
+  --text-dark: #1e1e1e;
+  --text-light: #ffffff;
+  --bg-light: #f9f6ff;
+}
+
+body {
+  margin: 0;
+  font-family: 'Poppins', sans-serif;
+  background-color: var(--bg-light);
+  color: var(--text-dark);
+  line-height: 1.6;
+}
+
+header {
+  background-color: var(--primary-color);
+  color: var(--text-light);
+  padding: 3rem 1rem 2rem;
+  text-align: center;
+}
+
+header img {
+  height: 72px;
+  border-radius: 20.5%;
+  border: 1px solid #ddd;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  margin-bottom: 1rem;
+}
+
+h1, h2 {
+  color: var(--secondary-color);
+}
+
+footer {
+  background-color: #f1eef6;
+  text-align: center;
+  color: #666;
+  padding: 1rem;
+  font-size: 0.9rem;
+}
+
+a {
+  color: var(--secondary-color);
+}
+
+a:hover {
+  color: var(--accent-color);
+}

--- a/data-deletion.html
+++ b/data-deletion.html
@@ -5,11 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta name="robots" content="noindex" />
   <title>Request Data Deletion - RecipeSnap AI</title>
+  <link rel="stylesheet" href="assets/theme.css">
   <style>
     body {
-      font-family: Arial, sans-serif;
-      background-color: #f6f6f6;
-      margin: 0;
       padding: 20px;
     }
     .container {
@@ -59,5 +57,8 @@
       You may also contact us directly at <a href="mailto:recipesnapai@gmail.com">recipesnapai@gmail.com</a>.
     </p>
   </div>
+  <footer style="text-align:center; margin-top:20px;">
+    <a href="terms-of-use.html">Terms of Use</a>
+  </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>RecipeSnap AI - Smarter Cooking Starts Here</title>
   <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
+  <link rel="stylesheet" href="assets/theme.css">
   <style>
     :root {
       --primary-color: #7b2cbf;
@@ -215,6 +216,9 @@
 
   <footer>
     &copy; 2025 RecipeSnap AI — Built with ❤️ to make cooking smarter.
+    <br>
+    <a href="privacy.html">Privacy</a> |
+    <a href="terms-of-use.html">Terms of Use</a>
   </footer>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -5,40 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Privacy Policy - RecipeSnap AI</title>
   <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
+  <link rel="stylesheet" href="assets/theme.css">
   <style>
-    body {
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background-color: #f9f9fb;
-      color: #333;
-      margin: 0;
-      padding: 0;
-    }
-    header {
-      background-color: #7b2cbf;
-      color: white;
-      padding: 2rem 1rem;
-      text-align: center;
-    }
-    header img {
-      width: 80px;
-      height: auto;
-      margin-bottom: 1rem;
-    }
     main {
       max-width: 900px;
       margin: auto;
       padding: 2rem 1.5rem;
       line-height: 1.6;
-    }
-    h1, h2 {
-      color: #5a189a;
-    }
-    footer {
-      background-color: #eee;
-      color: #666;
-      text-align: center;
-      padding: 1rem;
-      font-size: 0.9rem;
     }
   </style>
 </head>
@@ -81,7 +54,8 @@
     <p>If you have questions or concerns about this Privacy Policy, please email us at <a href="mailto:markmayne@ymail.com">markmayne@ymail.com</a>.</p>
   </main>
   <footer>
-    &copy; 2025 RecipeSnap AI. All rights reserved.
+    &copy; 2025 RecipeSnap AI. All rights reserved. |
+    <a href="terms-of-use.html">Terms of Use</a>
   </footer>
 </body>
 </html>

--- a/recipe.html
+++ b/recipe.html
@@ -5,38 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Recipe | RecipeSnap AI</title>
   <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
+  <link rel="stylesheet" href="assets/theme.css">
   <style>
-    :root {
-      --primary-color: #7b2cbf;
-      --secondary-color: #5a189a;
-      --accent-color: #3c096c;
-      --text-dark: #1e1e1e;
-      --text-light: #ffffff;
-      --bg-light: #f9f6ff;
-    }
 
-    body {
-      margin: 0;
-      font-family: 'Poppins', sans-serif;
-      background-color: var(--bg-light);
-      color: var(--text-dark);
-      line-height: 1.6;
-    }
-
-    header {
-      background-color: var(--primary-color);
-      color: var(--text-light);
-      padding: 3rem 1rem 2rem;
-      text-align: center;
-    }
-
-    header img {
-      height: 72px;
-      border-radius: 20.5%;
-      border: 1px solid #ddd;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
-      margin-bottom: 1rem;
-    }
 
     header h1 {
       font-size: 2.2rem;
@@ -218,6 +189,8 @@
     <footer>
       <p>Created and curated by <strong>RecipeSnap AI</strong></p>
       <a class="cta-button" href="https://apps.apple.com/us/app/recipesnap-ai/id6746269787">Download the App</a>
+      <br>
+      <a href="terms-of-use.html">Terms of Use</a>
     </footer>
   </div>
 </body>

--- a/support.html
+++ b/support.html
@@ -5,32 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Support - RecipeSnap AI</title>
   <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
+  <link rel="stylesheet" href="assets/theme.css">
   <style>
-    body {
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background-color: #f9f9fb;
-      color: #333;
-      margin: 0;
-      padding: 0;
-    }
-    header {
-      background-color: #7b2cbf;
-      color: white;
-      padding: 2rem 1rem;
-      text-align: center;
-    }
-    header img {
-      width: 80px;
-      height: auto;
-      margin-bottom: 1rem;
-    }
     main {
       max-width: 900px;
       margin: auto;
       padding: 2rem 1.5rem;
-    }
-    h1, h2 {
-      color: #5a189a;
     }
     p, li {
       line-height: 1.6;
@@ -44,18 +24,10 @@
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
     }
     a {
-      color: #5a189a;
       text-decoration: none;
     }
     a:hover {
       text-decoration: underline;
-    }
-    footer {
-      background-color: #eee;
-      color: #666;
-      text-align: center;
-      padding: 1rem;
-      font-size: 0.9rem;
     }
   </style>
 </head>
@@ -89,6 +61,7 @@
   </main>
   <footer>
     &copy; 2025 RecipeSnap AI. Need more help? Email <a href="mailto:markmayne@ymail.com">markmayne@ymail.com</a>
+    | <a href="terms-of-use.html">Terms of Use</a>
   </footer>
 </body>
 </html>

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Terms of Use - RecipeSnap AI</title>
+  <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
+  <link rel="stylesheet" href="assets/theme.css">
+  <style>
+    main {
+      max-width: 900px;
+      margin: auto;
+      padding: 2rem 1.5rem;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <img src="assets/images/RecipeSnapIcon.png" alt="RecipeSnap AI Icon" />
+    <h1>Terms of Use</h1>
+  </header>
+  <main>
+    <p>
+      By using RecipeSnap AI, you agree to abide by our
+      <a href="terms.html">Terms &amp; Conditions</a>, which govern your access and
+      use of the application. These terms outline acceptable use,
+      limitations of liability, and your responsibilities when using
+      our service.
+    </p>
+  </main>
+  <footer>
+    &copy; 2025 RecipeSnap AI. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -5,40 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Terms & Conditions - RecipeSnap AI</title>
   <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
+  <link rel="stylesheet" href="assets/theme.css">
   <style>
-    body {
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background-color: #f9f9fb;
-      color: #333;
-      margin: 0;
-      padding: 0;
-    }
-    header {
-      background-color: #7b2cbf;
-      color: white;
-      padding: 2.5rem 1rem;
-      text-align: center;
-    }
-    header img {
-      width: 80px;
-      height: auto;
-      margin-bottom: 1rem;
-    }
     main {
       max-width: 900px;
       margin: auto;
       padding: 2rem 1.5rem;
       line-height: 1.6;
-    }
-    h1, h2 {
-      color: #5a189a;
-    }
-    footer {
-      background-color: #eee;
-      color: #666;
-      text-align: center;
-      padding: 1rem;
-      font-size: 0.9rem;
     }
     ul {
       padding-left: 1.2rem;
@@ -87,7 +60,8 @@
     <p>If you have any questions about these Terms, please contact us at <a href="mailto:markmayne@ymail.com">markmayne@ymail.com</a>.</p>
   </main>
   <footer>
-    &copy; 2025 RecipeSnap AI. All rights reserved.
+    &copy; 2025 RecipeSnap AI. All rights reserved. |
+    <a href="terms-of-use.html">Terms of Use</a>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add site-wide theme stylesheet and apply to all pages
- create new `terms-of-use.html`
- link to the new policy in page footers
- document the theme in the README

## Testing
- `python3 test_auth.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684d96f5f8e883269eb185cba2f17868