### PR TITLE
Refine header colors for consistent styling

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -1,12 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
 
 :root {
-  --primary-color: #7b2cbf;
-  --secondary-color: #5a189a;
-  --accent-color: #3c096c;
-  --text-dark: #1e1e1e;
+  --primary-color: #673ab7;
+  --secondary-color: #4527a0;
+  --accent-color: #311b92;
+  --text-dark: #212121;
   --text-light: #ffffff;
-  --bg-light: #f9f6ff;
+  --bg-light: #f5f5f5;
 }
 
 body {
@@ -18,7 +18,7 @@ body {
 }
 
 header {
-  background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+  background: linear-gradient(135deg, var(--primary-color), var(--accent-color));
   color: var(--text-light);
   padding: 3rem 1rem 2rem;
   text-align: center;
@@ -33,7 +33,12 @@ header img {
 }
 
 h1, h2 {
-  color: var(--secondary-color);
+  color: var(--primary-color);
+}
+
+header h1,
+header h2 {
+  color: var(--text-light);
 }
 
 footer {
@@ -45,7 +50,7 @@ footer {
 }
 
 a {
-  color: var(--secondary-color);
+  color: var(--primary-color);
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- update color scheme variables
- refine header gradient and link colors
- ensure header text stays light for contrast

## Testing
- `python test_auth.py` *(fails: ModuleNotFoundError: No module named 'tweepy')*

------
https://chatgpt.com/codex/tasks/task_e_684da008d0788326a629793a2913d2a0