### PR TITLE
Implement device-aware store links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ This repository contains the static website for RecipeSnap AI.
 - Additional pages: `recipe.html`, `terms.html`, `privacy.html`
 - Assets (images and videos) are stored under the `assets/` directory.
 - Common styling lives in `assets/theme.css`.
+- The helper script `assets/store-link.js` swaps download links to the appropriate app store based on the user's device.

--- a/assets/store-link.js
+++ b/assets/store-link.js
@@ -1,0 +1,18 @@
+function updateStoreLinks() {
+  const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+  const android = /Android/.test(navigator.userAgent);
+  const appStore = 'https://apps.apple.com/us/app/recipesnap-ai/id6746269787';
+  const playStore = 'https://play.google.com/store/apps/details?id=com.markmayne.recipesnapai';
+  const storeURL = iOS ? appStore : android ? playStore : appStore;
+
+  document.querySelectorAll('.store-link').forEach(a => {
+    a.href = storeURL;
+    if (iOS) {
+      a.textContent = 'Download on the App Store';
+    } else if (android) {
+      a.textContent = 'Get it on Google Play';
+    }
+  });
+}
+
+window.addEventListener('DOMContentLoaded', updateStoreLinks);

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <h1>RecipeSnap AI</h1>
     <p>Turn Pantry Pics into Dinner Plans</p>
     <div class="top-cta">
-      <a href="https://apps.apple.com/us/app/recipesnap-ai/id6746269787" target="_blank">Download on the App Store</a>
+      <a class="store-link" href="https://apps.apple.com/us/app/recipesnap-ai/id6746269787" target="_blank">Download on the App Store</a>
     </div>
   </header>
 
@@ -55,7 +55,7 @@
 
   <div class="cta">
     <p>Smarter cooking is just a snap away.</p>
-    <a href="https://apps.apple.com/us/app/recipesnap-ai/id6746269787" target="_blank">Download on the App Store</a>
+    <a class="store-link" href="https://apps.apple.com/us/app/recipesnap-ai/id6746269787" target="_blank">Download on the App Store</a>
   </div>
 
   <footer>
@@ -64,5 +64,6 @@
     <a href="privacy.html">Privacy</a> |
     <a href="terms.html">Terms of Use</a>
   </footer>
+  <script src="assets/store-link.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add helper script to swap store links for Android vs iOS
- apply store-link handling on the homepage
- document new script in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tweepy')*

------
https://chatgpt.com/codex/tasks/task_e_68519a0fce8c8326affafc03c4aecba9